### PR TITLE
Fix issue with named argument paths.

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -2,6 +2,7 @@
 
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const ALPHA = /[A-Za-z]/;
+const WHITESPACE = /[\t\n\f ]/;
 
 class AngleBracketPolyfill {
   constructor(options) {
@@ -101,16 +102,26 @@ class AngleBracketPolyfill {
 
       let nodeSource = sourceForNode(element);
 
-      let firstChar;
-      for (let i = 0; i < nodeSource.length; i++) {
+      let tagNameStarted = false;
+      let tagName = '';
+      for (let i = 1 /* starting after the opening < */; i < nodeSource.length; i++) {
         let char = nodeSource[i];
-        if (char == '@' || ALPHA.test(char)) {
-          firstChar = char;
-          break;
+
+        if (tagNameStarted) {
+          if (char === '/' || char === '>' || WHITESPACE.test(char)) {
+            break;
+          } else {
+            tagName += char;
+          }
+        } else {
+          if (char == '@' || ALPHA.test(char)) {
+            tagNameStarted = true;
+            tagName += char;
+          }
         }
       }
 
-      return firstChar + element.tag.slice(1);
+      return tagName;
     }
 
     function getInvocationDetails(element) {

--- a/lib/sample-compile-script.js
+++ b/lib/sample-compile-script.js
@@ -11,6 +11,6 @@
 const compiler = require('ember-source/dist/ember-template-compiler');
 compiler.registerPlugin('ast', require('./ast-transform'));
 
-let template = '<span ...attributes>hi martin!</span>';
+let template = '<@nav.item />';
 let output = compiler.precompile(template, { contents: template });
 console.log(output); // eslint-disable-line no-console


### PR DESCRIPTION
Sadly this can't be tested just yet (using `{{@foo}}` on Ember < 3.1 throws an error during compilation, which fails the build and makes testing impossible).

I am working on that issue separately, but wanted to get this fix out first.