### PR TITLE
Add tests for `<@nav.item />` issue.

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -139,9 +139,17 @@ class AngleBracketPolyfill {
       let hasAttrSplat = element.attributes.find(n => n.name === '...attributes');
 
       if (isLocal || isNamedArgument || isThisPath) {
+        let path = b.path(tag);
+
+        if (isNamedArgument) {
+          path = b.path(tag.slice(1));
+          path.original = tag;
+          path.data = true;
+        }
+
         return {
           kind: 'DynamicComponent',
-          path: b.path(tag),
+          path,
           selfClosing,
           hasAttrSplat,
         };

--- a/lib/sample-compile-script.js
+++ b/lib/sample-compile-script.js
@@ -9,6 +9,7 @@
 */
 
 const compiler = require('ember-source/dist/ember-template-compiler');
+//compiler.registerPlugin('ast', require('ember-named-arguments-polyfill/lib/ast-transform'));
 compiler.registerPlugin('ast', require('./ast-transform'));
 
 let template = '<@curriedThing />';

--- a/lib/sample-compile-script.js
+++ b/lib/sample-compile-script.js
@@ -11,6 +11,6 @@
 const compiler = require('ember-source/dist/ember-template-compiler');
 compiler.registerPlugin('ast', require('./ast-transform'));
 
-let template = '<@nav.item />';
+let template = '<@curriedThing />';
 let output = compiler.precompile(template, { contents: template });
 console.log(output); // eslint-disable-line no-console

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-named-arguments-polyfill": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.2.0-beta.2",
     "ember-source-channel-url": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node": "6.* || 8.* || 9.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-named-arguments-polyfill"
   }
 }

--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -153,6 +153,24 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
       assert.dom().hasText('hi rwjblue!');
     });
 
+    test('invoke dynamic - named arguments', async function(assert) {
+      this.owner.register('template:components/x-invoker', hbs`<@curriedThing />`);
+      this.owner.register('template:components/foo-bar', hbs`hi rwjblue!`);
+
+      await render(hbs`{{x-invoker curriedThing=(component 'foo-bar')}}`);
+
+      assert.dom().hasText('hi rwjblue!');
+    });
+
+    test('invoke dynamic - named argument paths', async function(assert) {
+      this.owner.register('template:components/x-invoker', hbs`<@stuff.curriedThing />`);
+      this.owner.register('template:components/foo-bar', hbs`hi rwjblue!`);
+
+      await render(hbs`{{x-invoker stuff=(hash curriedThing=(component 'foo-bar'))}}`);
+
+      assert.dom().hasText('hi rwjblue!');
+    });
+
     test('invoke dynamic - path no implicit this', async function(assert) {
       this.owner.register('service:elsewhere', Service.extend());
       this.owner.register(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,6 +2153,13 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-named-arguments-polyfill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-named-arguments-polyfill/-/ember-named-arguments-polyfill-1.0.0.tgz#0b81fb81a7cef2c89e9e1d0278b579e708bf4ded"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-version-checker "^2.1.2"
+
 ember-qunit@^3.3.2:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.4.1.tgz#204a2d39a5d44d494c56bf17cf3fd12f06210359"


### PR DESCRIPTION
The tests here required creation of ember-named-arguments-polyfill to avoid build errors in Ember 2.10 when using named arguments.

These tests are for the issue fixed in https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill/pull/13.