### PR TITLE
TESTS: added block param w/ nested component + each-in example

### DIFF
--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -43,6 +43,37 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
       assert.dom().hasText('hi rwjblue!');
     });
 
+    test('yielding block param to nested child component using each-in', async function(assert) {
+      class ParentClazz extends Component {
+        get restaurants() {
+          return {
+            1: {
+              name: 'one',
+            },
+            2: {
+              name: 'two',
+            },
+          };
+        }
+        get layout() {
+          return hbs`{{yield restaurants}}`;
+        }
+      }
+
+      this.owner.register('component:the-parent', ParentClazz);
+      this.owner.register(
+        'template:components/the-child',
+        hbs`{{#each-in this.restaurants as |key item|}}<h1>{{item.name}}</h1>{{/each-in}}`
+      );
+
+      await render(
+        hbs`<TheParent as |restaurants|><TheChild @restaurants={{restaurants}} /></TheParent>`
+      );
+
+      assert.dom('h1:nth-of-type(1)').hasText('one');
+      assert.dom('h1:nth-of-type(2)').hasText('two');
+    });
+
     test('with arguments', async function(assert) {
       this.owner.register('template:components/foo-bar', hbs`<h2>{{title}}</h2>`);
 


### PR DESCRIPTION
@rwjblue this was the issue I was fighting w/ earlier today ;) thought to pass it on as a test scenario as proof that "yes Toran .... it does work"

If you prefer to throw it out that's cool also - was a fun learning experience tonight regardless :)