### PR TITLE
 fix: using ...attributes without passing attrs fails

### DIFF
--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -318,5 +318,16 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
 
       assert.dom('span[data-test-my-thing]').hasText('hi martin!');
     });
+
+    test('passing into element - unused', async function(assert) {
+      this.owner.register(
+        'template:components/foo-bar',
+        hbs`<span ...attributes>hi martin!</span>`
+      );
+
+      await render(hbs`<FooBar />`);
+
+      assert.dom('span').hasText('hi martin!');
+    });
   });
 });

--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -104,7 +104,7 @@ import { lte, gte } from 'ember-compatibility-helpers';
               let { positional } = args.capture();
               let invocationAttributesReference = positional.at(0);
               let invocationAttributes = invocationAttributesReference.value();
-              let attributeNames = Object.keys(invocationAttributes);
+              let attributeNames = invocationAttributes ? Object.keys(invocationAttributes) : [];
               let dynamicAttributes = {};
 
               for (let i = 0; i < attributeNames.length; i++) {
@@ -235,7 +235,7 @@ import { lte, gte } from 'ember-compatibility-helpers';
               let positional = gte('2.15.0-beta.1') ? args.capture().positional : args.positional;
               let invocationAttributesReference = positional.at(0);
               let invocationAttributes = invocationAttributesReference.value();
-              let attributeNames = Object.keys(invocationAttributes);
+              let attributeNames = invocationAttributes ? Object.keys(invocationAttributes) : [];
               let dynamicAttributes = {};
 
               for (let i = 0; i < attributeNames.length; i++) {


### PR DESCRIPTION
Example:
A component template with:
```hbs
<div ...attributes></div>
```
and this invocation:
```hbs
<MyComponent />
```
fails with:
```
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.create (runtime-polyfill.js:99)
```
This invocation succeeds:
```hbs
<MyComponent class="foo" />
```