### PR TITLE
Add test for merging of class names by ...attributes

### DIFF
--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -318,5 +318,17 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
 
       assert.dom('span[data-test-my-thing]').hasText('hi martin!');
     });
+
+    test('merge class names', async function(assert) {
+      this.owner.register(
+        'template:components/foo-bar',
+        hbs`<span class="original" ...attributes></span>`
+      );
+
+      await render(hbs`<FooBar class="new" />`);
+
+      assert.dom('span').hasClass('original');
+      assert.dom('span').hasClass('new');
+    });
   });
 });


### PR DESCRIPTION
This test fails. Expected behaviour is that if you create a component

```
<button class="button" ...attributes></button>
```

and invoke it using

```
<MyButton class="primary"></MyButton>
```

That the final element created would be 
```
<button class="button primary"></button>
```

but currently only the `primary` class gets assigned.