### PR TITLE
update confusing usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ but here are a few examples of "before"/"after" to whet your appetite:
 ```hbs
 <SiteHeader @user={{this.user}} class={{if this.user.isAdmin "admin"}} />
 
-<SuperSelect @selected={{this.user.country}} as |Option|>
+<SuperSelect @selected={{this.user.country}} as |s|>
   {{#each this.availableCountries as |country|}}
-    <Option @value={{country}}>{{country.name}}</Option>
+    <s.option @value={{country}}>{{country.name}}</s.option>
   {{/each}}
 </SuperSelect>
 ```


### PR DESCRIPTION
Example assumed that component yields a hash before but a component after changing syntax. Since angle bracket invocation does not affect yielded value it should be the same before and after.

It's the [same in RFC](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html#summary). Not quite sure if the RFC should be changed also even so it's already merged.