### PR TITLE
TravisCI: Remove deprecated `sudo: false` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ node_js:
   # so that your addon works for all apps
   - "6"
 
-sudo: false
-dist: trusty
-
 addons:
   chrome: stable
 


### PR DESCRIPTION
see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

/cc @rwjblue 