### PR TITLE
Fix class merging and attribute precedence

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -180,6 +180,48 @@ class AngleBracketPolyfill {
       }
     }
 
+    function attrsAsHash(attrs) {
+      if (attrs.length > 0) {
+        return b.sexpr(
+          'hash',
+          [],
+          b.hash(
+            attrs.map(attr => b.pair(attr.name, expressionForAttributeValue(attr.value), attr.loc))
+          )
+        );
+      }
+    }
+
+    function angleAttrsExpression(attributes) {
+      let preSplatAttributes = [];
+      let postSplatAttributes = [];
+      let foundSplat = false;
+
+      for (let i = 0; i < attributes.length; i++) {
+        let attr = attributes[i];
+        if (attr.name === '...attributes') {
+          foundSplat = true;
+        } else {
+          if (foundSplat) {
+            postSplatAttributes.push(attr);
+          } else {
+            preSplatAttributes.push(attr);
+          }
+        }
+      }
+
+      let attrGroups = [
+        attrsAsHash(preSplatAttributes),
+        foundSplat && b.path('__ANGLE_ATTRS__'),
+        attrsAsHash(postSplatAttributes),
+      ].filter(Boolean);
+      if (attrGroups.length > 1) {
+        return b.sexpr('-merge-attrs', attrGroups);
+      } else {
+        return attrGroups[0];
+      }
+    }
+
     let locals = [];
 
     let visitor = {
@@ -199,18 +241,16 @@ class AngleBracketPolyfill {
 
         if (invocation.kind === 'Element') {
           if (invocation.hasAttrSplat) {
-            node.attributes = node.attributes.filter(n => n.name !== '...attributes');
-            node.modifiers.push(b.elementModifier('_splattributes', [b.path('__ANGLE_ATTRS__')]));
+            let angle = angleAttrsExpression(node.attributes);
+            node.attributes = [];
+            node.modifiers.push(b.elementModifier('_splattributes', [angle]));
           }
-
           return;
         }
 
         let { children, blockParams } = node;
 
-        let attributes = node.attributes.filter(
-          node => node.name[0] !== '@' && node.name !== '...attributes'
-        );
+        let attributes = node.attributes.filter(node => node.name[0] !== '@');
         let args = node.attributes.filter(
           node => node.name[0] === '@' && node.name !== '...attributes'
         );
@@ -221,32 +261,8 @@ class AngleBracketPolyfill {
           )
         );
 
-        if (invocation.hasAttrSplat || attributes.length > 0) {
-          let attributesHash = b.sexpr(
-            '-merge-refs',
-            [],
-            b.hash(
-              [
-                attributes.length > 0 &&
-                  b.pair(
-                    'invocation',
-                    b.sexpr(
-                      'hash',
-                      [],
-                      b.hash(
-                        attributes.map(attr =>
-                          b.pair(attr.name, expressionForAttributeValue(attr.value), attr.loc)
-                        )
-                      )
-                    )
-                  ),
-
-                invocation.hasAttrSplat && b.pair('splat', b.path('__ANGLE_ATTRS__')),
-              ].filter(Boolean)
-            )
-          );
-
-          hash.pairs.push(b.pair('__ANGLE_ATTRS__', attributesHash));
+        if (attributes.length > 0) {
+          hash.pairs.push(b.pair('__ANGLE_ATTRS__', angleAttrsExpression(attributes)));
         }
 
         if (invocation.kind === 'StaticComponent') {

--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -318,5 +318,17 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
 
       assert.dom('span[data-test-my-thing]').hasText('hi martin!');
     });
+
+    test('merge class names', async function(assert) {
+      this.owner.register(
+        'template:components/foo-bar',
+        hbs`<span class="original" ...attributes></span>`
+      );
+
+      await render(hbs`<FooBar class="new" />`);
+
+      assert.dom('span').hasClass('original');
+      assert.dom('span').hasClass('new');
+    });
   });
 });

--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -6,6 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Service, { inject as injectService } from '@ember/service';
 import { helper as buildHelper } from '@ember/component/helper';
 import Component from '@ember/component';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('Integration | Component | angle-bracket-invocation', function(hooks) {
   setupRenderingTest(hooks);
@@ -426,18 +427,19 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
     });
 
     // This is broken in actual Ember, see
-    // https://github.com/emberjs/ember.js/pull/17533 We're skipping it here too
-    // because otherwise we get test failures on Ember 3.4+, where our polyfill
-    // is not in use.
-    skip('merges attributes in correct priority', async function(assert) {
-      this.owner.register(
-        'template:components/foo-bar',
-        hbs`<span data-left="left-inner" ...attributes data-right="right-inner"></span>`
-      );
-      await render(hbs`<FooBar data-left="left-outer" data-right="right-outer" />`);
+    // https://github.com/emberjs/ember.js/pull/17533. So we only test in
+    // versions where our polyfill is active.
+    if (!hasEmberVersion(3, 4)) {
+      test('merges attributes in correct priority', async function(assert) {
+        this.owner.register(
+          'template:components/foo-bar',
+          hbs`<span data-left="left-inner" ...attributes data-right="right-inner"></span>`
+        );
+        await render(hbs`<FooBar data-left="left-outer" data-right="right-outer" />`);
 
-      assert.dom('span').hasAttribute('data-left', 'left-outer');
-      assert.dom('span').hasAttribute('data-right', 'right-inner');
-    });
+        assert.dom('span').hasAttribute('data-left', 'left-outer');
+        assert.dom('span').hasAttribute('data-right', 'right-inner');
+      });
+    }
   });
 });

--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -414,7 +414,11 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
       assert.dom('span').hasText('hi martin!');
     });
 
-    test('merges attributes in correct priority', async function(assert) {
+    // This is broken in actual Ember, see
+    // https://github.com/emberjs/ember.js/pull/17533 We're skipping it here too
+    // because otherwise we get test failures on Ember 3.4+, where our polyfill
+    // is not in use.
+    skip('merges attributes in correct priority', async function(assert) {
       this.owner.register(
         'template:components/foo-bar',
         hbs`<span data-left="left-inner" ...attributes data-right="right-inner"></span>`

--- a/tests/integration/components/angle-bracket-invocation-test.js
+++ b/tests/integration/components/angle-bracket-invocation-test.js
@@ -414,6 +414,17 @@ module('Integration | Component | angle-bracket-invocation', function(hooks) {
       assert.dom('span').hasText('hi martin!');
     });
 
+    test('passing into element - unused with attributes present', async function(assert) {
+      this.owner.register(
+        'template:components/foo-bar',
+        hbs`<span class="hello" ...attributes>hi martin!</span>`
+      );
+
+      await render(hbs`<FooBar />`);
+
+      assert.dom('span').hasText('hi martin!');
+    });
+
     // This is broken in actual Ember, see
     // https://github.com/emberjs/ember.js/pull/17533 We're skipping it here too
     // because otherwise we get test failures on Ember 3.4+, where our polyfill

--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -12,7 +12,34 @@ import { lte, gte } from 'ember-compatibility-helpers';
     gte('2.13.0-alpha.1') ? '@glimmer/runtime' : 'glimmer-runtime'
   );
 
-  class WrappedNamedArguments {
+  // This is entirely cribbed from the real ClassListReference in glimmer-vm.
+  class ClassListReference {
+    constructor(list) {
+      this.tag = combineTagged(list);
+      this.list = list;
+    }
+
+    value() {
+      let ret = [];
+      let { list } = this;
+
+      for (let i = 0; i < list.length; i++) {
+        let value = this._normalizeStringValue(list[i].value());
+        if (value) ret.push(value);
+      }
+
+      return ret.length === 0 ? null : ret.join(' ');
+    }
+
+    _normalizeStringValue(value) {
+      if (value === null || value === undefined || typeof value.toString !== 'function') {
+        return '';
+      }
+      return String(value);
+    }
+  }
+
+  class MergedAttributesReference {
     constructor(references) {
       this.references = references;
 
@@ -24,33 +51,41 @@ import { lte, gte } from 'ember-compatibility-helpers';
     }
 
     value() {
-      return this.references;
+      let value = Object.create(null);
+      for (let key in this.references) {
+        value[key] = this.references[key].value();
+      }
+      return value;
+    }
+
+    get(property) {
+      return this.references[property];
     }
   }
 
-  function mergeRefsHelper(_vm, args) {
-    let invocationReferences = args.named.has('invocation') && args.named.get('invocation');
-    let splatReferences = args.named.has('splat') && args.named.get('splat').value();
-
+  function mergeAttributesHelper(_vm, args) {
     let references = {};
-
-    if (invocationReferences) {
-      let names = gte('2.15.0-beta.1') ? invocationReferences.names : invocationReferences.keys;
+    let classReferences = [];
+    for (let i = 0; i < args.positional.length; i++) {
+      let arg = args.positional.at(i);
+      let names = Object.keys(arg.value());
       for (let i = 0; i < names.length; i++) {
         let name = names[i];
-        let reference = invocationReferences.get(name);
-
-        references[name] = reference;
+        let reference = arg.get(name);
+        if (name === 'class') {
+          classReferences.push(reference);
+        } else {
+          references[name] = reference;
+        }
       }
     }
-
-    if (splatReferences) {
-      for (let attributeName in splatReferences) {
-        references[attributeName] = splatReferences[attributeName];
-      }
+    if (classReferences.length > 1) {
+      references['class'] = new ClassListReference(classReferences);
+    } else if (classReferences.length > 0) {
+      references['class'] = classReferences[0];
     }
 
-    return new WrappedNamedArguments(references);
+    return new MergedAttributesReference(references);
   }
 
   if (gte('3.1.0-beta.1')) {
@@ -86,7 +121,7 @@ import { lte, gte } from 'ember-compatibility-helpers';
           let runtimeResolver = compileTimeLookup.resolver;
 
           // setup our reference capture system
-          runtimeResolver.builtInHelpers['-merge-refs'] = mergeRefsHelper;
+          runtimeResolver.builtInHelpers['-merge-attrs'] = mergeAttributesHelper;
 
           class AttributeTracker {
             constructor(environment, element, attributeName, reference) {
@@ -122,19 +157,22 @@ import { lte, gte } from 'ember-compatibility-helpers';
               let invocationAttributes = invocationAttributesReference.value();
               let attributeNames = invocationAttributes ? Object.keys(invocationAttributes) : [];
               let dynamicAttributes = {};
+              let references = [];
 
               for (let i = 0; i < attributeNames.length; i++) {
                 let attributeName = attributeNames[i];
+                let ref = invocationAttributesReference.get(attributeName);
                 dynamicAttributes[attributeName] = new AttributeTracker(
                   environment,
                   element,
                   attributeName,
-                  invocationAttributes[attributeName]
+                  ref
                 );
+                references.push(ref);
               }
 
               return {
-                invocationAttributes,
+                references,
                 dynamicAttributes,
                 dom,
                 domBuilder,
@@ -142,12 +180,8 @@ import { lte, gte } from 'ember-compatibility-helpers';
               };
             },
 
-            getTag({ invocationAttributes }) {
-              let referencesArray = [];
-              for (let reference in invocationAttributes) {
-                referencesArray.push(invocationAttributes[reference]);
-              }
-              return combineTagged(referencesArray);
+            getTag({ references }) {
+              return combineTagged(references);
             },
 
             install(bucket) {
@@ -192,10 +226,11 @@ import { lte, gte } from 'ember-compatibility-helpers';
                 ORIGINAL_DID_CREATE_ELEMENT.apply(this, arguments);
                 let { args } = bucket;
                 if (args.has('__ANGLE_ATTRS__')) {
-                  let attributeReferences = args.get('__ANGLE_ATTRS__').value();
-                  for (let attributeName in attributeReferences) {
-                    let attributeReference = attributeReferences[attributeName];
-
+                  let angleAttrs = args.get('__ANGLE_ATTRS__');
+                  // this use of value is OK because the set of keys isn't allowed to change dynamically
+                  let snapshot = angleAttrs.value();
+                  for (let attributeName in snapshot) {
+                    let attributeReference = angleAttrs.get(attributeName);
                     operations.setAttribute(attributeName, attributeReference, false, null);
                   }
                 }
@@ -242,7 +277,7 @@ import { lte, gte } from 'ember-compatibility-helpers';
             let environment = ORIGINAL_ENVIRONMENT_CREATE.apply(this, arguments);
             let installedCustomDidCreateElement = false;
 
-            environment.builtInHelpers['-merge-refs'] = mergeRefsHelper;
+            environment.builtInHelpers['-merge-attrs'] = mergeAttributesHelper;
 
             class AttributeTracker {
               constructor(element, attributeName, reference) {
@@ -277,30 +312,29 @@ import { lte, gte } from 'ember-compatibility-helpers';
                 let invocationAttributes = invocationAttributesReference.value();
                 let attributeNames = invocationAttributes ? Object.keys(invocationAttributes) : [];
                 let dynamicAttributes = {};
+                let references = [];
 
                 for (let i = 0; i < attributeNames.length; i++) {
                   let attributeName = attributeNames[i];
+                  let ref = invocationAttributesReference.get(attributeName);
                   dynamicAttributes[attributeName] = new AttributeTracker(
                     element,
                     attributeName,
-                    invocationAttributes[attributeName]
+                    ref
                   );
+                  references.push(ref);
                 }
 
                 return {
-                  invocationAttributes,
+                  references,
                   dynamicAttributes,
                   dom,
                   environment,
                 };
               },
 
-              getTag({ invocationAttributes }) {
-                let referencesArray = [];
-                for (let reference in invocationAttributes) {
-                  referencesArray.push(invocationAttributes[reference]);
-                }
-                return combineTagged(referencesArray);
+              getTag({ references }) {
+                return combineTagged(references);
               },
 
               install(bucket) {
@@ -344,9 +378,11 @@ import { lte, gte } from 'ember-compatibility-helpers';
 
                   // on < 2.15 `namedArgs` is only present when there were arguments
                   if (args && args.has('__ANGLE_ATTRS__')) {
-                    let attributeReferences = args.get('__ANGLE_ATTRS__').value();
-                    for (let attributeName in attributeReferences) {
-                      let attributeReference = attributeReferences[attributeName];
+                    let attributeReferences = args.get('__ANGLE_ATTRS__');
+                    let names = Object.keys(attributeReferences.value());
+                    for (let i = 0; i < names.length; i++) {
+                      let attributeName = names[i];
+                      let attributeReference = attributeReferences.get(attributeName);
 
                       operations.addDynamicAttribute(
                         element,

--- a/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
+++ b/vendor/angle-bracket-invocation-polyfill/runtime-polyfill.js
@@ -68,14 +68,17 @@ import { lte, gte } from 'ember-compatibility-helpers';
     let classReferences = [];
     for (let i = 0; i < args.positional.length; i++) {
       let arg = args.positional.at(i);
-      let names = Object.keys(arg.value());
-      for (let i = 0; i < names.length; i++) {
-        let name = names[i];
-        let reference = arg.get(name);
-        if (name === 'class') {
-          classReferences.push(reference);
-        } else {
-          references[name] = reference;
+      let snapshot = arg.value();
+      if (snapshot) {
+        let names = Object.keys(arg.value());
+        for (let i = 0; i < names.length; i++) {
+          let name = names[i];
+          let reference = arg.get(name);
+          if (name === 'class') {
+            classReferences.push(reference);
+          } else {
+            references[name] = reference;
+          }
         }
       }
     }


### PR DESCRIPTION
This fixes #25.

In addition to special-casing the "class" attribute, this also fixes attribute precedence when an attribute is placed before vs after `...attributes`.

I eliminated the use of references whose value contains more references. I found it hard to reason about when composing across arbitrarily many levels. Now all the references represent true usermode values, and we use PathReference `get` for peeling individual references off of hashes.

Edit to add: forgot to mention, but now this polyfill is "more correct" than Ember until https://github.com/emberjs/ember.js/pull/17533 is fixed.