### PR TITLE
Fix transform to not touch native <input>

### DIFF
--- a/lib/ast-input-transform.js
+++ b/lib/ast-input-transform.js
@@ -2,7 +2,9 @@
 
 const checkAttributes = require('./helpers/check-attributes');
 const supportsAttribute = require('./helpers/supports-attribute');
+const getTag = require('./helpers/get-tag');
 
+const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const attributeToPropertyMap = {
   role: 'ariaRole',
 };
@@ -85,11 +87,13 @@ const checkboxAttributes = [
 class AngleBracketInputPolyfill {
   constructor(options) {
     this.moduleName = options.meta && options.meta.moduleName;
+    this.syntax = null;
+    this.sourceLines = options.contents && options.contents.match(reLines);
   }
 
   transform(ast) {
     let b = this.syntax.builders;
-    let { moduleName } = this;
+    let { moduleName, sourceLines } = this;
 
     // in order to debug in https://https://astexplorer.net/#/gist/0590eb883edfcd163b183514df4cc717
     // **** copy from here ****
@@ -104,15 +108,15 @@ class AngleBracketInputPolyfill {
 
     let visitor = {
       ElementNode(node) {
-        let tag = node.tag.toLowerCase();
+        let tag = getTag(node, sourceLines);
 
-        if (tag === 'input' || tag === 'textarea') {
+        if (tag === 'Input' || tag === 'Textarea') {
           let { attributes } = node;
           let isCheckbox =
-            tag === 'input' &&
+            tag === 'Input' &&
             attributes.find(({ name, value }) => name === '@type' && value.chars === 'checkbox');
           let supportedAttributes =
-            tag === 'textarea'
+            tag === 'Textarea'
               ? textareaAttributes
               : isCheckbox
               ? checkboxAttributes
@@ -137,7 +141,7 @@ class AngleBracketInputPolyfill {
             )
           );
 
-          return b.mustache(b.path(tag), null, hash, false, node.loc);
+          return b.mustache(b.path(tag.toLowerCase()), null, hash, false, node.loc);
         }
       },
     };

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const getTag = require('./helpers/get-tag');
+const sourceForNode = require('./helpers/source-for-node');
+
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const ALPHA = /[A-Za-z]/;
-const WHITESPACE = /[\t\r\n\f ]/;
 
 class AngleBracketPolyfill {
   constructor(options) {
@@ -50,37 +52,6 @@ class AngleBracketPolyfill {
       }
     }
 
-    // politely lifted from https://github.com/glimmerjs/glimmer-vm/blob/v0.35.0/packages/%40glimmer/syntax/lib/parser.ts#L113-L149
-    function sourceForNode(node) {
-      let firstLine = node.loc.start.line - 1;
-      let currentLine = firstLine - 1;
-      let firstColumn = node.loc.start.column;
-      let string = [];
-      let line;
-
-      let lastLine = node.loc.end.line - 1;
-      let lastColumn = node.loc.end.column;
-
-      while (currentLine < lastLine) {
-        currentLine++;
-        line = sourceLines[currentLine];
-
-        if (currentLine === firstLine) {
-          if (firstLine === lastLine) {
-            string.push(line.slice(firstColumn, lastColumn));
-          } else {
-            string.push(line.slice(firstColumn));
-          }
-        } else if (currentLine === lastLine) {
-          string.push(line.slice(0, lastColumn));
-        } else {
-          string.push(line);
-        }
-      }
-
-      return string.join('\n');
-    }
-
     function getSelfClosing(element) {
       if ('selfClosing' in element) {
         return element.selfClosing;
@@ -89,51 +60,14 @@ class AngleBracketPolyfill {
         return false;
       }
 
-      let nodeSource = sourceForNode(element);
+      let nodeSource = sourceForNode(element, sourceLines);
       let firstClosingBracketIndex = nodeSource.indexOf('>');
 
       return nodeSource[firstClosingBracketIndex - 1] === '/';
     }
 
-    /*
-      Ember < 3.1.0 mutates `element.tag` so that the first character
-      is _always_ lower case (even if the raw source includes upper case).
-
-      This function falls back to the raw source when possible to detect
-      the _actual_ first char.
-    */
-    function getTag(element) {
-      // if we have no source, we must use whatever element.tag has
-      if (!hasSourceAvailable) {
-        return element.tag;
-      }
-
-      let nodeSource = sourceForNode(element);
-
-      let tagNameStarted = false;
-      let tagName = '';
-      for (let i = 1 /* starting after the opening < */; i < nodeSource.length; i++) {
-        let char = nodeSource[i];
-
-        if (tagNameStarted) {
-          if (char === '/' || char === '>' || WHITESPACE.test(char)) {
-            break;
-          } else {
-            tagName += char;
-          }
-        } else {
-          if (char == '@' || ALPHA.test(char)) {
-            tagNameStarted = true;
-            tagName += char;
-          }
-        }
-      }
-
-      return tagName;
-    }
-
     function getInvocationDetails(element) {
-      let tag = getTag(element);
+      let tag = getTag(element, sourceLines);
       let invocationFirstChar = tag[0];
       let isNamedArgument = invocationFirstChar === '@';
       let isThisPath = tag.indexOf('this.') === 0;

--- a/lib/helpers/get-tag.js
+++ b/lib/helpers/get-tag.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const sourceForNode = require('./source-for-node');
+
+const ALPHA = /[A-Za-z]/;
+const WHITESPACE = /[\t\r\n\f ]/;
+
+/*
+  Ember < 3.1.0 mutates `element.tag` so that the first character
+  is _always_ lower case (even if the raw source includes upper case).
+
+  This function falls back to the raw source when possible to detect
+  the _actual_ first char.
+*/
+module.exports = function getTag(element, sourceLines) {
+  // if we have no source, we must use whatever element.tag has
+  if (!sourceLines || sourceLines.length === 0) {
+    return element.tag;
+  }
+
+  let nodeSource = sourceForNode(element, sourceLines);
+
+  let tagNameStarted = false;
+  let tagName = '';
+  for (let i = 1 /* starting after the opening < */; i < nodeSource.length; i++) {
+    let char = nodeSource[i];
+
+    if (tagNameStarted) {
+      if (char === '/' || char === '>' || WHITESPACE.test(char)) {
+        break;
+      } else {
+        tagName += char;
+      }
+    } else {
+      if (char == '@' || ALPHA.test(char)) {
+        tagNameStarted = true;
+        tagName += char;
+      }
+    }
+  }
+
+  return tagName;
+};

--- a/lib/helpers/source-for-node.js
+++ b/lib/helpers/source-for-node.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// politely lifted from https://github.com/glimmerjs/glimmer-vm/blob/v0.35.0/packages/%40glimmer/syntax/lib/parser.ts#L113-L149
+module.exports = function sourceForNode(node, sourceLines) {
+  let firstLine = node.loc.start.line - 1;
+  let currentLine = firstLine - 1;
+  let firstColumn = node.loc.start.column;
+  let string = [];
+  let line;
+
+  let lastLine = node.loc.end.line - 1;
+  let lastColumn = node.loc.end.column;
+
+  while (currentLine < lastLine) {
+    currentLine++;
+    line = sourceLines[currentLine];
+
+    if (currentLine === firstLine) {
+      if (firstLine === lastLine) {
+        string.push(line.slice(firstColumn, lastColumn));
+      } else {
+        string.push(line.slice(firstColumn));
+      }
+    } else if (currentLine === lastLine) {
+      string.push(line.slice(0, lastColumn));
+    } else {
+      string.push(line);
+    }
+  }
+
+  return string.join('\n');
+};

--- a/tests/integration/components/input-test.js
+++ b/tests/integration/components/input-test.js
@@ -71,4 +71,11 @@ module('Integration | Component | input', function(hooks) {
 
     assert.dom('input').exists();
   });
+
+  test('it passes <input> untouched', async function(assert) {
+    await render(hbs`<input />`);
+
+    assert.dom('input').exists();
+    assert.dom('input').doesNotHaveClass('ember-view');
+  });
 });


### PR DESCRIPTION
Fixes #78

That was a pretty stupid one: the transform would treat `<input />` the same as `<Input />`, i.e. transform it to `{{input}}`. 🤦‍♂️
Fixed that, added a test, and also tested it with the test suite of ember-bootstrap, which uncovered this issue as reported in #78.

Had to extract some of the existing helpers that work around the issue of earlier Ember version's AST returning the lower-cased tag name, to reuse them here.