### PR TITLE
Attempt to run steps sequentially (instead of in a single step).

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare .js and .hbs files to use lf only
+*.js text eol=lf
+*.hbs text eol=lf

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,12 +16,14 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 8.x
-    - name: install, lint, test
-      run: |
-        npm install -g yarn
-        yarn install
-        yarn lint:js
-        yarn test
+    - name: install yarn
+      run: npm install -g yarn
+    - name: install dependencies
+      run: yarn install
+    - name: lint
+      run: yarn lint:js
+    - name: test
+      run: yarn test
 
   try-scenarios:
     name: ${{ matrix.ember-try-scenario }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,10 +54,11 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
+    - name: install yarn
+      run: npm install -g yarn
+    - name: install dependencies
+      run: yarn install
     - name: test ${{ matrix.ember-try-scenario }}
       env:
         EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}
-      run: |
-        npm install -g yarn
-        yarn install
-        node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
+      run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,7 +58,7 @@ jobs:
       run: npm install -g yarn
     - name: install dependencies
       run: yarn install
-    - name: test ${{ matrix.ember-try-scenario }}
+    - name: test
       env:
         EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}
       run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
     "singleQuote": true,
     "trailingComma": "es5",
-    "printWidth": 100
+    "printWidth": 100,
+    "endOfLine": "lf"
   }


### PR DESCRIPTION
On Windows, we were only running our first command (not all of them).  Trying to work around that issue by making each step a separate entry (vs using the `run: |` syntax to run many in a single step).