### PR TITLE
Support for Unknown Attributes & Splattributes

### DIFF
--- a/lib/ast-input-transform.js
+++ b/lib/ast-input-transform.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const checkAttributes = require('./helpers/check-attributes');
-const supportsAttribute = require('./helpers/supports-attribute');
+const angleAttrsExpression = require('./helpers/angle-attrs-expression');
 const expressionForAttributeValue = require('./helpers/expression-for-attribute-value');
 const getTag = require('./helpers/get-tag');
 
@@ -10,91 +9,15 @@ const attributeToPropertyMap = {
   role: 'ariaRole',
 };
 
-const commonAttributes = [
-  'id',
-  'class',
-  'role',
-
-  // TextSupportMixin
-  'autocapitalize',
-  'autocorrect',
-  'autofocus',
-  'disabled',
-  'form',
-  'maxlength',
-  'minlength',
-  'placeholder',
-  'readonly',
-  'required',
-  'selectionDirection',
-  'spellcheck',
-  'tabindex',
-  'title',
-
-  /data-test-.+/, // support for ember-test-selectors
-];
-
-const inputAttributes = [
-  'accept',
-  'autocomplete',
-  'autosave',
-  'dir',
-  'formaction',
-  'formenctype',
-  'formmethod',
-  'formnovalidate',
-  'formtarget',
-  'height',
-  'inputmode',
-  'lang',
-  'list',
-  'type',
-  'max',
-  'min',
-  'multiple',
-  'name',
-  'pattern',
-  'size',
-  'step',
-  'value',
-  'width',
-].concat(commonAttributes);
-
-const textareaAttributes = [
-  'rows',
-  'cols',
-  'name',
-  'selectionEnd',
-  'selectionStart',
-  'autocomplete',
-  'wrap',
-  'lang',
-  'dir',
-  'value',
-].concat(commonAttributes);
-
-const checkboxAttributes = [
-  'type',
-  'checked',
-  'indeterminate',
-  'disabled',
-  'tabindex',
-  'name',
-  'autofocus',
-  'required',
-  'form',
-].concat(commonAttributes);
-
 class AngleBracketInputPolyfill {
   constructor(options) {
-    this.moduleName = options.meta && options.meta.moduleName;
     this.syntax = null;
     this.sourceLines = options.contents && options.contents.match(reLines);
   }
 
   transform(ast) {
     let b = this.syntax.builders;
-    let { moduleName, sourceLines } = this;
+    let { sourceLines } = this;
 
     // in order to debug in https://https://astexplorer.net/#/gist/0590eb883edfcd163b183514df4cc717
     // **** copy from here ****
@@ -104,34 +27,26 @@ class AngleBracketInputPolyfill {
 
         if (tag === 'Input' || tag === 'Textarea') {
           let { attributes } = node;
-          let isCheckbox =
-            tag === 'Input' &&
-            attributes.find(({ name, value }) => name === '@type' && value.chars === 'checkbox');
-          let supportedAttributes =
-            tag === 'Textarea'
-              ? textareaAttributes
-              : isCheckbox
-              ? checkboxAttributes
-              : inputAttributes;
-
-          checkAttributes(node, supportedAttributes, moduleName);
 
           let props = attributes
             .filter(({ name }) => name.charAt(0) === '@')
             .map(attribute => Object.assign({}, attribute, { name: attribute.name.slice(1) }));
-          let attrs = attributes
-            .filter(({ name }) => supportsAttribute(name, supportedAttributes))
+          let mappedAttrs = attributes
+            .filter(({ name }) => name.charAt(0) !== '@' && attributeToPropertyMap[name])
             .map(attribute =>
-              attributeToPropertyMap[attribute.name]
-                ? Object.assign({}, attribute, { name: attributeToPropertyMap[attribute.name] })
-                : attribute
-            );
+              Object.assign({}, attribute, { name: attributeToPropertyMap[attribute.name] }));
+          let attrs = attributes.filter(({ name }) => name.charAt(0) !== '@' && !attributeToPropertyMap[name]);
+
 
           let hash = b.hash(
-            [...props, ...attrs].map(({ name, value, loc }) =>
+            [...props, ...mappedAttrs].map(({ name, value, loc }) =>
               b.pair(name, expressionForAttributeValue(b, value), loc)
             )
           );
+
+          if (attrs.length > 0) {
+            hash.pairs.push(b.pair('__ANGLE_ATTRS__', angleAttrsExpression(b, attrs)));
+          }
 
           return b.mustache(b.path(tag.toLowerCase()), null, hash, false, node.loc);
         }

--- a/lib/ast-link-to-transform.js
+++ b/lib/ast-link-to-transform.js
@@ -1,34 +1,17 @@
 'use strict';
 
-const checkAttributes = require('./helpers/check-attributes');
-const supportsAttribute = require('./helpers/supports-attribute');
+const angleAttrsExpression = require('./helpers/angle-attrs-expression');
 const expressionForAttributeValue = require('./helpers/expression-for-attribute-value');
 const SilentError = require('silent-error');
 
 const reservedProps = ['@route', '@model', '@models', '@query'];
-const supportedHTMLAttributes = [
-  'id',
-  'class',
-  'rel',
-  'tabindex',
-  'title',
-  'target',
-  'role',
-
-  /data-test-.+/, // support for ember-test-selectors
-];
 const attributeToPropertyMap = {
   role: 'ariaRole',
 };
 
 class AngleBracketLinkToPolyfill {
-  constructor(options) {
-    this.moduleName = options.meta && options.meta.moduleName;
-  }
-
   transform(ast) {
     let b = this.syntax.builders;
-    let { moduleName } = this;
 
     // in order to debug in https://astexplorer.net/#/gist/0590eb883edfcd163b183514df4cc717/4f4fe68b6c9de49e633ceb7f41a0c13b6fcc6cc6
     // **** copy from here ****
@@ -49,8 +32,6 @@ class AngleBracketLinkToPolyfill {
               'You cannot provide both the `@model` and `@models` arguments to the <LinkTo> component.'
             );
           }
-
-          checkAttributes(node, supportedHTMLAttributes, moduleName);
 
           let needsParamsHelper =
             (models && models.value.path.original !== 'array') ||
@@ -91,19 +72,21 @@ class AngleBracketLinkToPolyfill {
           let props = attributes
             .filter(({ name }) => name.charAt(0) === '@' && !reservedProps.includes(name))
             .map(attribute => Object.assign({}, attribute, { name: attribute.name.slice(1) }));
-          let attrs = attributes
-            .filter(({ name }) => supportsAttribute(name, supportedHTMLAttributes))
+          let mappedAttrs = attributes
+            .filter(({ name }) => name.charAt(0) !== '@' && attributeToPropertyMap[name])
             .map(attribute =>
-              attributeToPropertyMap[attribute.name]
-                ? Object.assign({}, attribute, { name: attributeToPropertyMap[attribute.name] })
-                : attribute
-            );
+              Object.assign({}, attribute, { name: attributeToPropertyMap[attribute.name] }));
+          let attrs = attributes.filter(({ name }) => name.charAt(0) !== '@' && !attributeToPropertyMap[name]);
 
           let hash = b.hash(
-            [...props, ...attrs].map(({ name, value, loc }) =>
-              b.pair(name, expressionForAttributeValue(b, value), loc)
+            [...props, ...mappedAttrs].map(arg =>
+              b.pair(arg.name, expressionForAttributeValue(b, arg.value), arg.loc)
             )
           );
+
+          if (attrs.length > 0) {
+            hash.pairs.push(b.pair('__ANGLE_ATTRS__', angleAttrsExpression(b, attrs)));
+          }
 
           if (needsParamsHelper) {
             hash.pairs.push(

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -3,6 +3,7 @@
 const getTag = require('./helpers/get-tag');
 const sourceForNode = require('./helpers/source-for-node');
 const expressionForAttributeValue = require('./helpers/expression-for-attribute-value');
+const angleAttrsExpression = require('./helpers/angle-attrs-expression');
 
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const ALPHA = /[A-Za-z]/;
@@ -101,50 +102,6 @@ class AngleBracketPolyfill {
       }
     }
 
-    function attrsAsHash(attrs) {
-      if (attrs.length > 0) {
-        return b.sexpr(
-          'hash',
-          [],
-          b.hash(
-            attrs.map(attr =>
-              b.pair(attr.name, expressionForAttributeValue(b, attr.value), attr.loc)
-            )
-          )
-        );
-      }
-    }
-
-    function angleAttrsExpression(attributes) {
-      let preSplatAttributes = [];
-      let postSplatAttributes = [];
-      let foundSplat = false;
-
-      for (let i = 0; i < attributes.length; i++) {
-        let attr = attributes[i];
-        if (attr.name === '...attributes') {
-          foundSplat = true;
-        } else {
-          if (foundSplat) {
-            postSplatAttributes.push(attr);
-          } else {
-            preSplatAttributes.push(attr);
-          }
-        }
-      }
-
-      let attrGroups = [
-        attrsAsHash(preSplatAttributes),
-        foundSplat && b.path('__ANGLE_ATTRS__'),
-        attrsAsHash(postSplatAttributes),
-      ].filter(Boolean);
-      if (attrGroups.length > 1) {
-        return b.sexpr('-merge-attrs', attrGroups);
-      } else {
-        return attrGroups[0];
-      }
-    }
-
     let locals = [];
 
     let visitor = {
@@ -164,7 +121,7 @@ class AngleBracketPolyfill {
 
         if (invocation.kind === 'Element') {
           if (invocation.hasAttrSplat) {
-            let angle = angleAttrsExpression(node.attributes);
+            let angle = angleAttrsExpression(b, node.attributes);
             node.attributes = [];
             node.modifiers.push(b.elementModifier('_splattributes', [angle]));
           }
@@ -185,7 +142,7 @@ class AngleBracketPolyfill {
         );
 
         if (attributes.length > 0) {
-          hash.pairs.push(b.pair('__ANGLE_ATTRS__', angleAttrsExpression(attributes)));
+          hash.pairs.push(b.pair('__ANGLE_ATTRS__', angleAttrsExpression(b, attributes)));
         }
 
         if (invocation.kind === 'StaticComponent') {

--- a/lib/helpers/angle-attrs-expression.js
+++ b/lib/helpers/angle-attrs-expression.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const expressionForAttributeValue = require('./expression-for-attribute-value');
+
+function attrsAsHash(b, attrs) {
+  if (attrs.length > 0) {
+    return b.sexpr(
+      'hash',
+      [],
+      b.hash(
+        attrs.map(attr =>
+          b.pair(attr.name, expressionForAttributeValue(b, attr.value), attr.loc)
+        )
+      )
+    );
+  }
+}
+
+module.exports = function angleAttrsExpression(b, attributes) {
+  let preSplatAttributes = [];
+  let postSplatAttributes = [];
+  let foundSplat = false;
+
+  for (let i = 0; i < attributes.length; i++) {
+    let attr = attributes[i];
+    if (attr.name === '...attributes') {
+      foundSplat = true;
+    } else {
+      if (foundSplat) {
+        postSplatAttributes.push(attr);
+      } else {
+        preSplatAttributes.push(attr);
+      }
+    }
+  }
+
+  let attrGroups = [
+    attrsAsHash(b, preSplatAttributes),
+    foundSplat && b.path('__ANGLE_ATTRS__'),
+    attrsAsHash(b, postSplatAttributes),
+  ].filter(Boolean);
+  if (attrGroups.length > 1) {
+    return b.sexpr('-merge-attrs', attrGroups);
+  } else {
+    return attrGroups[0];
+  }
+}


### PR DESCRIPTION
* Brings over arbitrary attribute and splattribute support from general component transform
* Removes checks for "supported attributes" now that any attribute is supported
* Ensures that attributes mapped to properties are not treated as `ANGLE_ATTRS`