### PR TITLE
Include polyfill for Ember 3.4

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -27,6 +27,7 @@ jobs:
 
   try-scenarios:
     name: ${{ matrix.ember-try-scenario }}
+    continue-on-error: ${{ matrix.allow-failure }}
 
     runs-on: ubuntu-latest
 
@@ -43,9 +44,15 @@ jobs:
          - ember-3.2
          - ember-3.3
          - ember-lts-3.4
-         - ember-lts-3.8
-         - ember-lts-3.28
          - ember-default
+
+        allow-failure: [false]
+
+        include:
+          - ember-try-scenario: ember-lts-3.8
+            allow-failure: true
+          - ember-try-scenario: ember-lts-3.28
+            allow-failure: true
 
     steps:
     - uses: actions/checkout@v1

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     let checker = new VersionChecker(this.project);
     let emberVersion = checker.forEmber();
 
-    this.shouldPolyfill = emberVersion.lt('3.4.0-alpha.1');
+    this.shouldPolyfill = emberVersion.lt('3.5.0-alpha.1');
     this.shouldPolyfillNested = emberVersion.lt('3.10.0-alpha.1');
     this.shouldPolyfillBuiltinComponents = emberVersion.lt('3.10.0-alpha.1');
 


### PR DESCRIPTION
This is a more conservative version of the existing PR: https://github.com/ember-polyfills/ember-angle-bracket-invocation-polyfill/pull/123.

In Ember 3.4 (w/o the polyfill), angle-bracket invocations do not work properly in some cases. For example:

- `<FooBar class="some-class" />`
- `<FooBar data-test="some-data-test" />`
